### PR TITLE
fix torch model size exception when parsing nodes without edges

### DIFF
--- a/java/src/main/scala/com/tencent/angel/pytorch/graph/gcn/GCNPartition.scala
+++ b/java/src/main/scala/com/tencent/angel/pytorch/graph/gcn/GCNPartition.scala
@@ -206,7 +206,7 @@ class GCNPartition(index: Int,
     val batchIterator = keys.indices.sliding(batchSize, batchSize)
     val keysIterator = new Iterator[Array[(Long, Long, String)]] with Serializable {
       override def hasNext: Boolean = {
-        if (!batchIterator.hasNext) TorchModel.put(torch)
+        if (!batchIterator.hasNext && !parseAloneNodes) TorchModel.put(torch)
         batchIterator.hasNext
       }
 
@@ -222,7 +222,10 @@ class GCNPartition(index: Int,
       val aloneNodes = model.getNodesWithOutDegree(index, numPartitions)
       val aloneBatchIterator = aloneNodes.sliding(batchSize, batchSize)
       val aloneIterator = new Iterator[Array[(Long, Long, String)]] with Serializable {
-        override def hasNext: Boolean = aloneBatchIterator.hasNext
+        override def hasNext: Boolean = {
+          if (!aloneBatchIterator.hasNext) TorchModel.put(torch)
+          aloneBatchIterator.hasNext
+        }
 
         override def next: Array[(Long, Long, String)] = {
           val batch = aloneBatchIterator.next()
@@ -299,7 +302,7 @@ class GCNPartition(index: Int,
     val batchIterator = keys.indices.sliding(batchSize, batchSize)
     val keysIterator = new Iterator[Array[(Long, Long, String, String)]] with Serializable {
       override def hasNext: Boolean = {
-        if (!batchIterator.hasNext) TorchModel.put(torch)
+        if (!batchIterator.hasNext && !parseAloneNodes) TorchModel.put(torch)
         batchIterator.hasNext
       }
 
@@ -315,7 +318,10 @@ class GCNPartition(index: Int,
       val aloneNodes = model.getNodesWithOutDegree(index, numPartitions)
       val aloneBatchIterator = aloneNodes.sliding(batchSize, batchSize)
       val aloneIterator = new Iterator[Array[(Long, Long, String, String)]] with Serializable {
-        override def hasNext: Boolean = aloneBatchIterator.hasNext
+        override def hasNext: Boolean = {
+          if (!aloneBatchIterator.hasNext) TorchModel.put(torch)
+          aloneBatchIterator.hasNext
+        }
 
         override def next: Array[(Long, Long, String, String)] = {
           val batch = aloneBatchIterator.next()

--- a/java/src/main/scala/com/tencent/angel/pytorch/graph/gcn/GNNPartition.scala
+++ b/java/src/main/scala/com/tencent/angel/pytorch/graph/gcn/GNNPartition.scala
@@ -88,7 +88,7 @@ class GNNPartition(index: Int,
 
     val keyIterator = new Iterator[Array[(Long, String)]] with Serializable {
       override def hasNext: Boolean = {
-        if (!batchIterator.hasNext) TorchModel.put(torch)
+        if (!batchIterator.hasNext && !parseAloneNodes) TorchModel.put(torch)
         batchIterator.hasNext
       }
 
@@ -104,7 +104,10 @@ class GNNPartition(index: Int,
       val aloneNodes = model.getNodesWithOutDegree(index, numPartitions)
       val aloneBatchIterator = aloneNodes.sliding(batchSize, batchSize)
       val aloneIterator = new Iterator[Array[(Long, String)]] with Serializable {
-        override def hasNext: Boolean = aloneBatchIterator.hasNext
+        override def hasNext: Boolean = {
+          if (!aloneBatchIterator.hasNext) TorchModel.put(torch)
+          aloneBatchIterator.hasNext
+        }
 
 
         override def next: Array[(Long, String)] = {


### PR DESCRIPTION
在使用GraphSage做预测或者生成embedding时，会报The size of torch model exceeds the cores的异常。发现是在处理孤立节点时，没有放回TorchModel。经过多次（10次+）以上的测试验证，没有报错。